### PR TITLE
feat: Add obs_output_get_id

### DIFF
--- a/libobs-sharp.example/Program.cs
+++ b/libobs-sharp.example/Program.cs
@@ -147,6 +147,9 @@ namespace LibObs.example {
                 var ph = obs_output_get_proc_handler(bufferOutput);
                 Console.WriteLine("buffer output successful save: " + proc_handler_call(ph, "save", cd));
             });
+            
+            Console.WriteLine("Record Output id is " + obs_output_get_id(recordOutput));
+            Console.WriteLine("Buffer Output id is " + obs_output_get_id(bufferOutput));
 
             Console.ReadLine();
         }

--- a/libobs-sharp/Output.cs
+++ b/libobs-sharp/Output.cs
@@ -111,5 +111,9 @@ namespace LibObs {
 
         [DllImport(importLibrary, CallingConvention = importCall)]
         public static extern proc_handler_t obs_output_get_proc_handler(obs_output_t output);
+
+        [DllImport(importLibrary, CallingConvention = importCall)]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8StringMarshaler))]
+        public static extern string obs_output_get_id(obs_output_t output);
     }
 }


### PR DESCRIPTION
Adds the `obs_output_get_id` to the library so RePlays can differenciate between a `replay_buffer` output and a normal recording output